### PR TITLE
Support airgaped environment

### DIFF
--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -37,32 +37,45 @@ def go_deps():
     if "com_github_google_go_containerregistry" not in excludes:
         go_repository(
             name = "com_github_google_go_containerregistry",
-            commit = "e5f4efd48dbff3ab3165a944d6777f8db28f0ccb",
+            urls = ["https://codeload.github.com/google/go-containerregistry/zip/e5f4efd48dbff3ab3165a944d6777f8db28f0ccb"], # v0.1.2
+            strip_prefix = "go-containerregistry-e5f4efd48dbff3ab3165a944d6777f8db28f0ccb",
+            sha256 = "ba9b5ae737f9b7ae153f20cad6d4a56b94949afec1fcb638bb1e3e7cc0028923",
             importpath = "github.com/google/go-containerregistry",
+            type = "zip",
         )
     if "com_github_pkg_errors" not in excludes:
         go_repository(
             name = "com_github_pkg_errors",
-            commit = "614d223910a179a466c1767a985424175c39b465",  # v0.9.1
+            urls = ["https://codeload.github.com/pkg/errors/zip/614d223910a179a466c1767a985424175c39b465"], # v0.9.1
+            sha256 = "49c7041442cc15211ee85175c06ffa6520c298b1826ed96354c69f16b6cfd13b",
             importpath = "github.com/pkg/errors",
+            strip_prefix = "errors-614d223910a179a466c1767a985424175c39b465",
+            type = "zip",
         )
 
     if "in_gopkg_yaml_v2" not in excludes:
         go_repository(
             name = "in_gopkg_yaml_v2",
-            commit = "53403b58ad1b561927d19068c655246f2db79d48",  # v2.2.8
+            urls = ["https://codeload.github.com/go-yaml/yaml/zip/53403b58ad1b561927d19068c655246f2db79d48"], # v2.2.8
+            sha256 = "6ba5e7e5a1cffe05e7628b8cb441ee860d75e439e567187330b5f5d8d72c1537",
             importpath = "gopkg.in/yaml.v2",
+            strip_prefix = "yaml-53403b58ad1b561927d19068c655246f2db79d48",
+            type = "zip",
         )
     if "com_github_kylelemons_godebug" not in excludes:
         go_repository(
             name = "com_github_kylelemons_godebug",
-            commit = "9ff306d4fbead574800b66369df5b6144732d58e",  # v1.1.0
+            urls = ["https://codeload.github.com/kylelemons/godebug/zip/9ff306d4fbead574800b66369df5b6144732d58e"], # v1.1.0
+            sha256 = "117fb85c4d3e6bf9fe55ad2379aca71fee8f7157f025733a7fb40835a8729188",
             importpath = "github.com/kylelemons/godebug",
+            strip_prefix = "godebug-9ff306d4fbead574800b66369df5b6144732d58e",
+            type = "zip",
         )
     if "com_github_ghodss_yaml" not in excludes:
         go_repository(
             name = "com_github_ghodss_yaml",
+            urls = ["https://codeload.github.com/ghodss/yaml/zip/0ca9ea5df5451ffdf184b4428c902747c2c11cd7"], # v1.0.0
+            sha256 = "6775fdc9ff61c99b9d9ea03df0af793f41d6ec4a7cdbcd04eae1d9911acdf6f9",
             importpath = "github.com/ghodss/yaml",
-            sum = "h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=",
-            version = "v1.0.0",
+            strip_prefix = "yaml-0ca9ea5df5451ffdf184b4428c902747c2c11cd7",
         )


### PR DESCRIPTION
`go_repository` git commit doesn't support `http_load` cache mechanism thus prevents `rules_docker` to be used in air gapped environment.
Replacing it with `urls` makes `go_repository` to use `http_load` and utilize cache mechanism if needed.